### PR TITLE
fix: [CDS-93908]: add permissions for upgrader to update statefulset

### DIFF
--- a/templates/upgrader/role.yaml
+++ b/templates/upgrader/role.yaml
@@ -24,6 +24,7 @@ rules:
     - apps
     resources:
     - deployments
+    - statefulsets
     verbs:
     - get
     - list


### PR DESCRIPTION
Upgrader requires permission to update statefulset image version