### PR TITLE
fix: [CDS-97699]: Fix installing agent with custom CA

### DIFF
--- a/templates/gitops-agent/secret.yaml
+++ b/templates/gitops-agent/secret.yaml
@@ -10,7 +10,7 @@ stringData:
   GITOPS_AGENT_TOKEN: |
     {{ .Values.harness.secrets.agentSecret }}
 ---
-{{ if .Values.harness.secrets.caData.enabled }}
+{{- if .Values.harness.secrets.caData.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -18,9 +18,10 @@ metadata:
     {{- include "harness.agentLabels" (dict "context" . "component" .Values.agent.name "name" "agent-ca") | nindent 4 }}
   name: {{ .Values.agent.name }}-ca
   namespace: {{ .Release.Namespace }}
-  stringData:
-    ca.bundle: |
-{{ .Values.harness.secrets.caData.secret  }}
+type: Opaque
+stringData:
+  ca.bundle: |
+    {{ .Values.harness.secrets.caData.secret }}
 ---
 {{- end }}
 apiVersion: v1
@@ -30,11 +31,11 @@ metadata:
     {{- include "harness.agentLabels" (dict "context" . "component" .Values.agent.name "name" "agent-ssh") | nindent 4 }}
   name: {{ .Values.agent.name }}-mtls
   namespace: {{ .Release.Namespace }}
+type: Opaque
 data:
   client.crt: |
-{{- .Values.harness.secrets.mtlsClientCert | nindent 4}}
+    {{ .Values.harness.secrets.mtlsClientCert }}
   client.key: |
-{{- .Values.harness.secrets.mtlsClientKey | nindent 4}}
----
+    {{ .Values.harness.secrets.mtlsClientKey }}
 
 


### PR DESCRIPTION
Fixes yaml parse problem when providing custom CA in override file or through helm install command.
```
Error: YAML parse error on gitops-helm/templates/gitops-agent/secret.yaml: error converting YAML to JSON: yaml: line 17: could not find expected ':'
```
@mankrit-singh 