### PR TITLE
fix: [CDS-103262]: Add checksum for agent deployment secrets

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: gitops-helm
 description: A Helm chart for Harness GitOps Agent - for more information, please visit https://developer.harness.io/docs/category/gitops.
-version: 1.1.11
+version: 1.1.12
 dependencies:
   - name: argo-cd
     version: 6.7.18

--- a/charts/templates/gitops-agent/deployment.yaml
+++ b/charts/templates/gitops-agent/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
         {{- end }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/gitops-agent/secret.yaml") . | sha256sum }}
       labels:
         {{- include "harness.agentLabels" (dict "context" . "component" .Values.agent.name "name" .Values.agent.name) | nindent 8 }}
         {{- with .Values.agent.podLabels }}


### PR DESCRIPTION
## Description
Add sha256 checksum for all gitops deployment related secrets 

### Test cases
- [x] helm template test .
<img width="856" alt="Screenshot 2024-11-13 at 11 56 19" src="https://github.com/user-attachments/assets/a9f468c8-cf90-4598-b2bd-cf3351f9aaa6">

- [x] helm template test .  --set harness.secrets.agentSecret=nil
<img width="857" alt="Screenshot 2024-11-13 at 11 57 09" src="https://github.com/user-attachments/assets/1c4a8d31-7be8-40b5-be26-e86a2cd5cf0d">

- [x] helm template test .  --set harness.secrets.agentSecret=some-secret
<img width="874" alt="Screenshot 2024-11-13 at 11 57 51" src="https://github.com/user-attachments/assets/2f0f8a41-983c-451c-873f-3baf74bbd44a">
